### PR TITLE
Enable manual GitHub action run

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  # Allow manual triggering of the workflow from the GitHub UI
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- allow workflow_dispatch on macOS build workflow

## Testing
- `make all` *(fails: bats missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878fae82540832a8c24f1c7229ba480