### PR TITLE
Add homebrew installation workflow

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,15 @@
+name: Homebrew Installation Test
+
+on:
+  schedule:
+    - cron: '0 0 */14 * *'
+  workflow_dispatch:
+
+jobs:
+  homebrew-install:
+    runs-on: macos-latest
+    steps:
+      - name: Install via Homebrew
+        run: brew install azhuchkov/tools/tunblkctl
+      - name: Check usage output
+        run: tunblkctl 2>&1 | grep -q "Usage:"


### PR DESCRIPTION
## Summary
- add scheduled workflow to verify installation via Homebrew

## Testing
- `make all` *(fails: `bats` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879089c0a68832a84265ea253c3ce78