### PR TITLE
Add macOS arch matrix for homebrew install test

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   homebrew-install:
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [X64, ARM64]
+    runs-on:
+      labels: macos-latest
+      architecture: ${{ matrix.arch }}
     steps:
       - name: Install via Homebrew
         run: brew install azhuchkov/tools/tunblkctl


### PR DESCRIPTION
## Summary
- test Homebrew install on latest macOS for both Intel and Apple Silicon runners

## Testing
- `make all` *(fails: `bats` missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a80257328832abb8b91cf008538e0